### PR TITLE
feat: add optional middleware support to makeServer

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "./contextws": {
       "require": "./src/contextws.js"
     },
+    "./ws": {
+      "require": "./src/ws.js"
+    },
     "./man": {
       "require": "./src/man.js"
     }

--- a/src/ws.js
+++ b/src/ws.js
@@ -22,7 +22,7 @@ function getPublicIPv4() {
   return 'localhost';
 }
 
-function makeServer({ port, static, root, ctx }) {
+function makeServer({ port, static, root, ctx }, middleware) {
   root = path.join(root || process.cwd());
 
   function sendFile(filePath, res){ 
@@ -49,6 +49,12 @@ function makeServer({ port, static, root, ctx }) {
     if (!static) {
       res.writeHead(200, { 'Content-Type': 'text/plain' });
       return res.end("ok");
+    }
+
+    // If middleware is provided and handles the request, stop here.
+    if (middleware) {
+      var handled = middleware(req, res, root, sendFile);
+      if (handled) return;
     }
 
     let filePath = req.url === '/' ? '/index.html' : req.url;


### PR DESCRIPTION
- makeServer accepts optional middleware function as second arg
- middleware runs before default static file handler
- if middleware returns true, request is considered handled
- add ./ws export to package.json

This enables projects to use tune ws programmatically with custom routing such as SPA fallback for clean URLs.